### PR TITLE
Correct leap example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,9 +230,9 @@ let g:remotions_motions = {
    \       'motion_plug' : '<Plug>(leap-forward-to)'
    \   },
    \   'leap_bck' : {
-   \       'backward' : '<Plug>(leapbackward)',
-   \       'forward' : '<Plug>(leapforward)',
-   \       'motion': 's',
+   \       'backward' : '<Plug>(leapforward)',
+   \       'forward' : '<Plug>(leapbackward)',
+   \       'motion': 'S',
    \       'motion_plug' : '<Plug>(leap-backward-to)'
    \   },
    \ }


### PR DESCRIPTION
`S` is used to move backward, and therefore `'forward'` should keep moving backward.